### PR TITLE
177: use `num_elements` instead of `size`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@ Development release.
 ## Bug fixes
 
 - Added a missing `@family` tag to the `pcens` functions. This omission resulted in the Weibull analytical solution not being visible in the package documentation.
+- Changed a call to `size()` to use `num_elements()` instead as an underlying type conversion was causing issues on some platforms.
 
 # primarycensored 1.0.0
 

--- a/inst/stan/functions/primarycensored.stan
+++ b/inst/stan/functions/primarycensored.stan
@@ -37,8 +37,8 @@ real primarycensored_cdf(data real d, int dist_id, array[] real params,
   } else {
     // Use numerical integration for other cases
     real lower_bound = max({d - pwindow, 1e-6});
-    array[size(params) + size(primary_params)] real theta = append_array(params, primary_params);
-    array[4] int ids = {dist_id, primary_id, size(params), size(primary_params)};
+    array[num_elements(params) + num_elements(primary_params)] real theta = append_array(params, primary_params);
+    array[4] int ids = {dist_id, primary_id, num_elements(params), num_elements(primary_params)};
 
     vector[1] y0 = rep_vector(0.0, 1);
     result = ode_rk45(primarycensored_ode, y0, lower_bound, {d}, theta, {d, pwindow}, ids)[1, 1];


### PR DESCRIPTION
<!-- Thanks for opening this pull request! Below we have provided a suggested template for PRs to this repository and a checklist to complete before opening a PR -->
 
## Description

This PR closes #177 by replacing `size` with `num_elements`.

## Checklist

- [X] My PR is based on a package issue and I have explicitly linked it.
- [X] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [X] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [X] I have tested my changes locally.
- [ ] I have added or updated unit tests where necessary.
- [ ] I have updated the documentation if required.
- [ ] My code follows the established coding standards.
- [ ] I have added a news item linked to this PR.
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->
