### PR TITLE
181: pre-assign sizes to variables

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ Authors@R:
            comment = c(ORCID = "0000-0003-2386-4031")),
     person(given = "Sebastian",
            family = "Funk",
-           role = c("ctb"),
+           role = c("aut"),
            email = "sebastian.funk@lshtm.ac.uk",
            comment = c(ORCID = "0000-0002-2842-3406")))
 Description: Provides functions for working with primary

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@ Development release.
 ## Bug fixes
 
 - Added a missing `@family` tag to the `pcens` functions. This omission resulted in the Weibull analytical solution not being visible in the package documentation.
+- Added precalculation of vector sizes to the `primarycensored_cdf()` stan function, avoiding errors on some platforms due to narrowing conversions in aggregate initialisation. 
 
 # primarycensored 1.0.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,7 +11,6 @@ Development release.
 ## Bug fixes
 
 - Added a missing `@family` tag to the `pcens` functions. This omission resulted in the Weibull analytical solution not being visible in the package documentation.
-- Changed a call to `size()` to use `num_elements()` instead as an underlying type conversion was causing issues on some platforms.
 
 # primarycensored 1.0.0
 

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -63,6 +63,7 @@ pcd
 pcens
 pdist
 pprimarycensored
+precalculation
 primaryeventdistributions
 propto
 pwindow

--- a/inst/stan/functions/primarycensored.stan
+++ b/inst/stan/functions/primarycensored.stan
@@ -37,8 +37,10 @@ real primarycensored_cdf(data real d, int dist_id, array[] real params,
   } else {
     // Use numerical integration for other cases
     real lower_bound = max({d - pwindow, 1e-6});
-    array[size(params) + size(primary_params)] real theta = append_array(params, primary_params);
-    array[4] int ids = {dist_id, primary_id, size(params), size(primary_params)};
+    int params_size = size(params);
+    int primary_params_size = size(primary_params);
+    array[params_size + primary_params_size] real theta = append_array(params, primary_params);
+    array[4] int ids = {dist_id, primary_id, params_size, primary_params_size};
 
     vector[1] y0 = rep_vector(0.0, 1);
     result = ode_rk45(primarycensored_ode, y0, lower_bound, {d}, theta, {d, pwindow}, ids)[1, 1];

--- a/inst/stan/functions/primarycensored.stan
+++ b/inst/stan/functions/primarycensored.stan
@@ -37,10 +37,10 @@ real primarycensored_cdf(data real d, int dist_id, array[] real params,
   } else {
     // Use numerical integration for other cases
     real lower_bound = max({d - pwindow, 1e-6});
-    int params_size = size(params);
-    int primary_params_size = size(primary_params);
-    array[params_size + primary_params_size] real theta = append_array(params, primary_params);
-    array[4] int ids = {dist_id, primary_id, params_size, primary_params_size};
+    int n_params = size(params);
+    int n_primary_params = size(primary_params);
+    array[n_params + n_primary_params] real theta = append_array(params, primary_params);
+    array[4] int ids = {dist_id, primary_id, n_params, n_primary_params};
 
     vector[1] y0 = rep_vector(0.0, 1);
     result = ode_rk45(primarycensored_ode, y0, lower_bound, {d}, theta, {d, pwindow}, ids)[1, 1];

--- a/inst/stan/functions/primarycensored.stan
+++ b/inst/stan/functions/primarycensored.stan
@@ -37,8 +37,8 @@ real primarycensored_cdf(data real d, int dist_id, array[] real params,
   } else {
     // Use numerical integration for other cases
     real lower_bound = max({d - pwindow, 1e-6});
-    array[num_elements(params) + num_elements(primary_params)] real theta = append_array(params, primary_params);
-    array[4] int ids = {dist_id, primary_id, num_elements(params), num_elements(primary_params)};
+    array[size(params) + size(primary_params)] real theta = append_array(params, primary_params);
+    array[4] int ids = {dist_id, primary_id, size(params), size(primary_params)};
 
     vector[1] y0 = rep_vector(0.0, 1);
     result = ode_rk45(primarycensored_ode, y0, lower_bound, {d}, theta, {d, pwindow}, ids)[1, 1];


### PR DESCRIPTION
<!-- Thanks for opening this pull request! Below we have provided a suggested template for PRs to this repository and a checklist to complete before opening a PR -->
 
## Description

This PR closes #181.

It fixes the issue by assigning sizes to int first (where type conversion is permitted) and then brace-initialise.

If we agree on the solution I'll add a new news item.

## Checklist

- [X] My PR is based on a package issue and I have explicitly linked it.
- [X] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [X] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [X] I have tested my changes locally.
- [x] I have added or updated unit tests where necessary.
- [x] I have updated the documentation if required.
- [x] My code follows the established coding standards.
- [x] I have added a news item linked to this PR.
- [x] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->
