### PR TITLE
Issue #71: Adds support for varying right truncation and primary windows to fitdistdoublecens

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,11 @@ This the development version
     solutions to be added in future versions using the same interface as `pcens_cdf()`.
   - `qpcens()` and `qprimarycensored()`: Convenient wrapper functions that provide
     alternative interfaces to `pcens_quantile()`.
+- Added support to `fitdistdoublecens()` to allow for varying primary censoring windows and truncation times. As part of this refactor the interface has also been improved to allow for more flexible data input.
+
+## Documentation
+
+- Updated the `fitdistrplus` vignette to use more complex data where the relative observation time is not constant. Also removed the note that the `fitdistdoublecens()` function is limited to a single primary censoring windows and truncation time as this is no longer the case.
 
 # primarycensored 1.1.0
 

--- a/R/check.R
+++ b/R/check.R
@@ -58,11 +58,10 @@ check_pdist <- function(pdist, D, ...) {
 #' @examples
 #' check_dprimary(dunif, pwindow = 1)
 check_dprimary <- function(
-  dprimary,
-  pwindow,
-  dprimary_args = list(),
-  tolerance = 1e-3
-) {
+    dprimary,
+    pwindow,
+    dprimary_args = list(),
+    tolerance = 1e-3) {
   # check if dprimary takes min and max as arguments
   if (!all(c("min", "max") %in% names(formals(dprimary)))) {
     stop("dprimary must take min and max as arguments", call. = FALSE)
@@ -113,6 +112,10 @@ check_truncation <- function(delays, D, multiplier = 2) {
     stop("All arguments must be numeric.", call. = FALSE)
   }
 
+  if (length(D) > 1) {
+    stop("D must be a single value for check_truncation", call. = FALSE)
+  }
+
   if (D <= 0 || multiplier <= 1) {
     stop(
       "Invalid argument values. D must be positive and multiplier must be ",
@@ -151,6 +154,5 @@ check_truncation <- function(delays, D, multiplier = 2) {
       )
     )
   }
-
   invisible(NULL)
 }

--- a/R/fitdistdoublecens.R
+++ b/R/fitdistdoublecens.R
@@ -56,29 +56,31 @@
 #'
 #' delay_data <- data.frame(
 #'   left = samples,
-#'   right = samples + swindow
+#'   right = samples + swindow,
+#'   pwindow = rep(pwindow, n),
+#'   D = rep(D, n)
 #' )
 #'
 #' fit_norm <- fitdistdoublecens(
 #'   delay_data,
 #'   distr = "norm",
-#'   start = list(mean = 0, sd = 1),
-#'   D = D, pwindow = pwindow
+#'   start = list(mean = 0, sd = 1)
 #' )
 #'
 #' summary(fit_norm)
 fitdistdoublecens <- function(
-    censdata,
-    distr,
-    left = "left",
-    right = "right",
-    pwindow = "pwindow",
-    D = "D",
-    dprimary = stats::dunif,
-    dprimary_name = lifecycle::deprecated(),
-    dprimary_args = list(),
-    truncation_check_multiplier = 2,
-    ...) {
+  censdata,
+  distr,
+  left = "left",
+  right = "right",
+  pwindow = "pwindow",
+  D = "D",
+  dprimary = stats::dunif,
+  dprimary_name = lifecycle::deprecated(),
+  dprimary_args = list(),
+  truncation_check_multiplier = 2,
+  ...
+) {
   nms <- .name_deprecation(lifecycle::deprecated(), dprimary_name)
   if (!is.null(nms$dprimary)) {
     dprimary <- add_name_attribute(dprimary, nms$dprimary)
@@ -187,10 +189,12 @@ fitdistdoublecens <- function(
   formals(ppcens_dist) <- formals(pdist)
 
   # Fit the distribution
+  delays <- censdata[[left]]
+
   fit <- withr::with_environment(
     environment(),
     fitdistrplus::fitdist(
-      censdata[[left]],
+      delays,
       distr = "pcens_dist",
       ...
     )
@@ -206,12 +210,13 @@ fitdistdoublecens <- function(
 #' truncation times for each element in x.
 #' @keywords internal
 .dpcens <- function(
-    x,
-    params,
-    pdist,
-    dprimary,
-    dprimary_args,
-    ...) {
+  x,
+  params,
+  pdist,
+  dprimary,
+  dprimary_args,
+  ...
+) {
   tryCatch(
     {
       unique_params <- unique(params)

--- a/R/fitdistdoublecens.R
+++ b/R/fitdistdoublecens.R
@@ -188,11 +188,12 @@ fitdistdoublecens <- function(
   }
   formals(ppcens_dist) <- formals(pdist)
 
+  delays <- censdata[[left]]
   # Create a clean environment with only the necessary objects
   fit_env <- new.env(parent = emptyenv())
 
   # Copy only the required objects to the clean environment
-  fit_env$delays <- censdata[[left]]
+  fit_env$delays <- delays
   fit_env$ppcens_dist <- ppcens_dist
   fit_env$dpcens_dist <- dpcens_dist
 

--- a/R/fitdistdoublecens.R
+++ b/R/fitdistdoublecens.R
@@ -104,7 +104,7 @@ fitdistdoublecens <- function(
   # Deprecation handling for pwindow and D
   if (is.numeric(pwindow)) {
     lifecycle::deprecate_warn(
-      "1.0.0",
+      "1.1.0",
       "fitdistdoublecens(pwindow)",
       details = "Use pwindow column in censdata instead."
     )
@@ -113,7 +113,7 @@ fitdistdoublecens <- function(
   }
   if (is.numeric(D)) {
     lifecycle::deprecate_warn(
-      "1.0.0",
+      "1.1.0",
       "fitdistdoublecens(D)",
       details = "Use D column in censdata instead."
     )

--- a/R/fitdistdoublecens.R
+++ b/R/fitdistdoublecens.R
@@ -188,11 +188,17 @@ fitdistdoublecens <- function(
   }
   formals(ppcens_dist) <- formals(pdist)
 
-  # Fit the distribution
-  delays <- censdata[[left]]
+  # Create a clean environment with only the necessary objects
+  fit_env <- new.env(parent = emptyenv())
 
+  # Copy only the required objects to the clean environment
+  fit_env$delays <- censdata[[left]]
+  fit_env$ppcens_dist <- ppcens_dist
+  fit_env$dpcens_dist <- dpcens_dist
+
+  # Perform the fitting in the clean environment
   fit <- withr::with_environment(
-    globalenv(),
+    fit_env,
     fitdistrplus::fitdist(
       delays,
       distr = "pcens_dist",
@@ -237,19 +243,19 @@ fitdistdoublecens <- function(
         result <- numeric(length(x))
 
         for (i in seq_len(nrow(unique_params))) {
-          swindow <- unique_params$swindow[i]
-          pwindow <- unique_params$pwindow[i]
-          D <- unique_params$D[i] # nolint
-          mask <- params$swindow == swindow &
-            params$pwindow == pwindow &
-            params$D == D
+          sw <- unique_params$swindow[i]
+          pw <- unique_params$pwindow[i]
+          Ds <- unique_params$D[i] # nolint
+          mask <- params$swindow == sw &
+            params$pwindow == pw &
+            params$D == Ds
 
           result[mask] <- dprimarycensored(
             x[mask],
             pdist,
-            pwindow = pwindow,
-            swindow = swindow,
-            D = D,
+            pwindow = pw,
+            swindow = sw,
+            D = Ds,
             dprimary = dprimary,
             dprimary_args = dprimary_args,
             ...

--- a/R/fitdistdoublecens.R
+++ b/R/fitdistdoublecens.R
@@ -188,19 +188,17 @@ fitdistdoublecens <- function(
   }
   formals(ppcens_dist) <- formals(pdist)
 
-  # Assign the density and distribution functions to global environment
-  assign("dpcens_dist", dpcens_dist, envir = globalenv())
-  assign("ppcens_dist", ppcens_dist, envir = globalenv())
-
   # Fit the distribution
   delays <- censdata[[left]]
 
-  fit <-
+  fit <- withr::with_environment(
+    globalenv(),
     fitdistrplus::fitdist(
       delays,
       distr = "pcens_dist",
       ...
     )
+  )
   return(fit)
 }
 
@@ -241,7 +239,7 @@ fitdistdoublecens <- function(
         for (i in seq_len(nrow(unique_params))) {
           swindow <- unique_params$swindow[i]
           pwindow <- unique_params$pwindow[i]
-          D <- unique_params$D[i]
+          D <- unique_params$D[i] # nolint
           mask <- params$swindow == swindow &
             params$pwindow == pwindow &
             params$D == D

--- a/R/fitdistdoublecens.R
+++ b/R/fitdistdoublecens.R
@@ -188,17 +188,19 @@ fitdistdoublecens <- function(
   }
   formals(ppcens_dist) <- formals(pdist)
 
+  # Assign the density and distribution functions to global environment
+  assign("dpcens_dist", dpcens_dist, envir = globalenv())
+  assign("ppcens_dist", ppcens_dist, envir = globalenv())
+
   # Fit the distribution
   delays <- censdata[[left]]
 
-  fit <- withr::with_environment(
-    environment(),
+  fit <-
     fitdistrplus::fitdist(
       delays,
       distr = "pcens_dist",
       ...
     )
-  )
   return(fit)
 }
 

--- a/R/fitdistdoublecens.R
+++ b/R/fitdistdoublecens.R
@@ -16,6 +16,17 @@
 #'
 #' @param distr A character string naming the distribution to be fitted.
 #'
+#' @param left Column name for lower bound of observed values (default: "left").
+#'
+#' @param right Column name for upper bound of observed values (default:
+#'  "right").
+#'
+#' @param pwindow Column name for primary window (default: "pwindow").
+#'
+#' @param D Column name for maximum delay (truncation point). If finite, the
+#'  distribution is truncated at D. If set to Inf, no truncation is applied.
+#'  (default: "D").
+#'
 #' @inheritParams pprimarycensored
 #'
 #' @param ... Additional arguments to be passed to [fitdistrplus::fitdist()].
@@ -59,8 +70,10 @@
 fitdistdoublecens <- function(
     censdata,
     distr,
-    pwindow = 1,
-    D = Inf,
+    left = "left",
+    right = "right",
+    pwindow = "pwindow",
+    D = "D",
     dprimary = stats::dunif,
     dprimary_name = lifecycle::deprecated(),
     dprimary_args = list(),
@@ -86,22 +99,56 @@ fitdistdoublecens <- function(
     )
   }
 
-  if (!all(c("left", "right") %in% names(censdata))) {
-    stop("censdata must contain 'left' and 'right' columns", call. = FALSE)
+  # Deprecation handling for pwindow and D
+  if (is.numeric(pwindow)) {
+    lifecycle::deprecate_warn(
+      "1.0.0",
+      "fitdistdoublecens(pwindow)",
+      details = "Use pwindow column in censdata instead."
+    )
+    censdata[["pwindow"]] <- pwindow
+    pwindow <- "pwindow"
+  }
+  if (is.numeric(D)) {
+    lifecycle::deprecate_warn(
+      "1.0.0",
+      "fitdistdoublecens(D)",
+      details = "Use D column in censdata instead."
+    )
+    censdata[["D"]] <- D
+    D <- "D"
+  }
+
+  required_cols <- c(left, right, pwindow, D)
+  missing_cols <- setdiff(required_cols, names(censdata))
+  if (length(missing_cols) > 0) {
+    stop(
+      "Missing required columns: ",
+      toString(missing_cols),
+      call. = FALSE
+    )
   }
 
   if (!is.null(truncation_check_multiplier)) {
-    check_truncation(
-      delays = censdata$left,
-      D = D,
-      multiplier = truncation_check_multiplier
-    )
+    unique_D <- unique(censdata[[D]])
+    for (d in unique_D) {
+      delays_subset <- censdata[[left]][censdata[[D]] == d]
+      check_truncation(
+        delays = delays_subset,
+        D = d,
+        multiplier = truncation_check_multiplier
+      )
+    }
   }
 
   # Get the distribution functions
   pdist_name <- paste0("p", distr)
   pdist <- add_name_attribute(get(pdist_name), pdist_name)
-  swindows <- censdata$right - censdata$left
+  params <- data.frame(
+    swindow = censdata[[right]] - censdata[[left]],
+    pwindow = censdata[[pwindow]],
+    D = censdata[[D]]
+  )
 
   # Create the function definition with named arguments for dpcens
   dpcens_dist <- function() {
@@ -111,10 +158,8 @@ fitdistdoublecens <- function(
       c(
         env_args,
         list(
-          swindows = swindows,
+          params = params,
           pdist = pdist,
-          pwindow = pwindow,
-          D = D,
           dprimary = dprimary,
           dprimary_args = dprimary_args
         )
@@ -131,9 +176,8 @@ fitdistdoublecens <- function(
       c(
         env_args,
         list(
+          params = params,
           pdist = pdist,
-          pwindow = pwindow,
-          D = D,
           dprimary = dprimary,
           dprimary_args = dprimary_args
         )
@@ -146,7 +190,7 @@ fitdistdoublecens <- function(
   fit <- withr::with_environment(
     environment(),
     fitdistrplus::fitdist(
-      censdata$left,
+      censdata[[left]],
       distr = "pcens_dist",
       ...
     )
@@ -157,50 +201,55 @@ fitdistdoublecens <- function(
 #' Define a fitdistrplus compatible wrapper around dprimarycensored
 #' @inheritParams dprimarycensored
 #'
-#' @param swindows A numeric vector of secondary window sizes corresponding to
-#' each element in x
+#' @param params A data frame with columns 'swindow', 'pwindow', and 'D'
+#' corresponding to the secondary window sizes, primary window sizes, and
+#' truncation times for each element in x.
 #' @keywords internal
 .dpcens <- function(
     x,
-    swindows,
+    params,
     pdist,
-    pwindow,
-    D,
     dprimary,
     dprimary_args,
     ...) {
   tryCatch(
     {
-      if (length(unique(swindows)) == 1) {
+      unique_params <- unique(params)
+      # Check if all parameters are constant
+      if (nrow(unique_params) == 1) {
         dprimarycensored(
           x,
           pdist,
-          pwindow = pwindow,
-          swindow = swindows[1],
-          D = D,
+          pwindow = unique_params$pwindow[1],
+          swindow = unique_params$swindow[1],
+          D = unique_params$D[1],
           dprimary = dprimary,
           dprimary_args = dprimary_args,
           ...
         )
       } else {
-        # Group x and swindows by unique swindow values
-        unique_swindows <- unique(swindows)
+        # Group by unique combinations of parameters
         result <- numeric(length(x))
 
-        for (sw in unique_swindows) {
-          mask <- swindows == sw
+        for (i in seq_len(nrow(unique_params))) {
+          swindow <- unique_params$swindow[i]
+          pwindow <- unique_params$pwindow[i]
+          D <- unique_params$D[i]
+          mask <- params$swindow == swindow &
+            params$pwindow == pwindow &
+            params$D == D
+
           result[mask] <- dprimarycensored(
             x[mask],
             pdist,
             pwindow = pwindow,
-            swindow = sw,
+            swindow = swindow,
             D = D,
             dprimary = dprimary,
             dprimary_args = dprimary_args,
             ...
           )
         }
-
         result
       }
     },
@@ -213,17 +262,26 @@ fitdistdoublecens <- function(
 #' Define a fitdistrplus compatible wrapper around pprimarycensored
 #' @inheritParams pprimarycensored
 #' @keywords internal
-.ppcens <- function(q, pdist, pwindow, D, dprimary, dprimary_args, ...) {
+.ppcens <- function(q, params, pdist, dprimary, dprimary_args, ...) {
   tryCatch(
     {
-      pprimarycensored(
+      # Vectorize the CDF calculation
+      mapply(
+        function(q_i, pw, D_i) {
+          pprimarycensored(
+            q_i,
+            pdist,
+            pwindow = pw,
+            D = D_i,
+            dprimary = dprimary,
+            dprimary_args = dprimary_args,
+            ...
+          )
+        },
         q,
-        pdist,
-        pwindow = pwindow,
-        D = D,
-        dprimary = dprimary,
-        dprimary_args = dprimary_args,
-        ...
+        params$pwindow,
+        params$D,
+        SIMPLIFY = TRUE
       )
     },
     error = function(e) {

--- a/man/dot-dpcens.Rd
+++ b/man/dot-dpcens.Rd
@@ -4,23 +4,19 @@
 \alias{.dpcens}
 \title{Define a fitdistrplus compatible wrapper around dprimarycensored}
 \usage{
-.dpcens(x, swindows, pdist, pwindow, D, dprimary, dprimary_args, ...)
+.dpcens(x, params, pdist, dprimary, dprimary_args, ...)
 }
 \arguments{
 \item{x}{Vector of quantiles}
 
-\item{swindows}{A numeric vector of secondary window sizes corresponding to
-each element in x}
+\item{params}{A data frame with columns 'swindow', 'pwindow', and 'D'
+corresponding to the secondary window sizes, primary window sizes, and
+truncation times for each element in x.}
 
 \item{pdist}{Distribution function (CDF). The package can identify base R
 distributions for potential analytical solutions. For non-base R functions,
 users can apply \code{\link[=add_name_attribute]{add_name_attribute()}} to yield properly tagged
 functions if they wish to leverage the analytical solutions.}
-
-\item{pwindow}{Primary event window}
-
-\item{D}{Maximum delay (truncation point). If finite, the distribution is
-truncated at D. If set to Inf, no truncation is applied. Defaults to Inf.}
 
 \item{dprimary}{Function to generate the probability density function
 (PDF) of primary event times. This function should take a value \code{x} and a

--- a/man/dot-ppcens.Rd
+++ b/man/dot-ppcens.Rd
@@ -4,7 +4,7 @@
 \alias{.ppcens}
 \title{Define a fitdistrplus compatible wrapper around pprimarycensored}
 \usage{
-.ppcens(q, pdist, pwindow, D, dprimary, dprimary_args, ...)
+.ppcens(q, params, pdist, dprimary, dprimary_args, ...)
 }
 \arguments{
 \item{q}{Vector of quantiles}
@@ -13,11 +13,6 @@
 distributions for potential analytical solutions. For non-base R functions,
 users can apply \code{\link[=add_name_attribute]{add_name_attribute()}} to yield properly tagged
 functions if they wish to leverage the analytical solutions.}
-
-\item{pwindow}{Primary event window}
-
-\item{D}{Maximum delay (truncation point). If finite, the distribution is
-truncated at D. If set to Inf, no truncation is applied. Defaults to Inf.}
 
 \item{dprimary}{Function to generate the probability density function
 (PDF) of primary event times. This function should take a value \code{x} and a

--- a/man/fitdistdoublecens.Rd
+++ b/man/fitdistdoublecens.Rd
@@ -7,8 +7,10 @@
 fitdistdoublecens(
   censdata,
   distr,
-  pwindow = 1,
-  D = Inf,
+  left = "left",
+  right = "right",
+  pwindow = "pwindow",
+  D = "D",
   dprimary = stats::dunif,
   dprimary_name = lifecycle::deprecated(),
   dprimary_args = list(),
@@ -24,10 +26,16 @@ upper or lower bounds.}
 
 \item{distr}{A character string naming the distribution to be fitted.}
 
-\item{pwindow}{Primary event window}
+\item{left}{Column name for lower bound of observed values (default: "left").}
 
-\item{D}{Maximum delay (truncation point). If finite, the distribution is
-truncated at D. If set to Inf, no truncation is applied. Defaults to Inf.}
+\item{right}{Column name for upper bound of observed values (default:
+"right").}
+
+\item{pwindow}{Column name for primary window (default: "pwindow").}
+
+\item{D}{Column name for maximum delay (truncation point). If finite, the
+distribution is truncated at D. If set to Inf, no truncation is applied.
+(default: "D").}
 
 \item{dprimary}{Function to generate the probability density function
 (PDF) of primary event times. This function should take a value \code{x} and a

--- a/man/fitdistdoublecens.Rd
+++ b/man/fitdistdoublecens.Rd
@@ -94,14 +94,15 @@ samples <- rprimarycensored(
 
 delay_data <- data.frame(
   left = samples,
-  right = samples + swindow
+  right = samples + swindow,
+  pwindow = rep(pwindow, n),
+  D = rep(D, n)
 )
 
 fit_norm <- fitdistdoublecens(
   delay_data,
   distr = "norm",
-  start = list(mean = 0, sd = 1),
-  D = D, pwindow = pwindow
+  start = list(mean = 0, sd = 1)
 )
 
 summary(fit_norm)

--- a/tests/testthat/test-check_truncation.R
+++ b/tests/testthat/test-check_truncation.R
@@ -25,7 +25,9 @@ test_that("check_truncation warns for empty delays vector", {
 test_that("check_truncation handles delays with NA and Inf values", {
   expect_silent(
     check_truncation(
-      delays = c(1, 2, NA, 4, Inf), D = 10, multiplier = 2
+      delays = c(1, 2, NA, 4, Inf),
+      D = 10,
+      multiplier = 2
     )
   )
 })
@@ -60,5 +62,12 @@ test_that("check_truncation errors on multiplier <= 1", {
 test_that("check_truncation is silent when D is infinite", {
   expect_silent(
     check_truncation(delays = c(1, 2, 3, 4), D = Inf, multiplier = 2)
+  )
+})
+
+test_that("check_truncation errors when D has length > 1", {
+  expect_error(
+    check_truncation(delays = c(1, 2, 3, 4), D = c(5, 10), multiplier = 2),
+    "D must be a single value for check_truncation"
   )
 })

--- a/tests/testthat/test-fitdistdoublecens.R
+++ b/tests/testthat/test-fitdistdoublecens.R
@@ -81,15 +81,15 @@ test_that("fitdistdoublecens works with deprecated numeric inputs", {
   )
 
   # Test with deprecated numeric inputs for pwindow and D
-  expect_warning(
-    fit <- fitdistdoublecens(
-      delay_data,
-      distr = "gamma",
-      start = list(shape = 1, rate = 1),
-      pwindow = 1,
-      D = 8
-    ),
-    "deprecated"
+  suppressWarnings(
+    expect_warning(
+      fit <- fitdistdoublecens( # nolint
+        delay_data,
+        distr = "gamma",
+        start = list(shape = 1, rate = 1),
+        pwindow = 1,
+        D = 8
+    )
   )
 
   # Check that the function returns a fitdist object

--- a/tests/testthat/test-fitdistdoublecens.R
+++ b/tests/testthat/test-fitdistdoublecens.R
@@ -3,7 +3,7 @@ if (!requireNamespace("fitdistrplus", quietly = TRUE)) {
   skip("Package 'fitdistrplus' is required for these tests")
 }
 
-test_that("fitdistdoublecens works correctly", {
+test_that("fitdistdoublecens works correctly with column names", {
   # Set seed for reproducibility
   set.seed(123)
 
@@ -14,23 +14,28 @@ test_that("fitdistdoublecens works correctly", {
 
   # Generate samples
   samples <- rprimarycensored(
-    n, rgamma,
-    shape = shape, rate = rate,
-    pwindow = 1, swindow = 1, D = 8
+    n,
+    rgamma,
+    shape = shape,
+    rate = rate,
+    pwindow = 1,
+    swindow = 1,
+    D = 8
   )
 
-  # Create data frame
+  # Create data frame with column names
   delay_data <- data.frame(
-    left = samples
+    left = samples,
+    right = samples + 1,
+    pwindow = rep(1, n),
+    D = rep(8, n)
   )
-  delay_data$right <- delay_data$left + 1
 
   # Fit the model using fitdistdoublecens
   fit <- fitdistdoublecens(
     delay_data,
     distr = "gamma",
-    start = list(shape = 1, rate = 1),
-    D = 8, pwindow = 1
+    start = list(shape = 1, rate = 1)
   )
 
   # Check that the function returns a fitdist object
@@ -49,20 +54,71 @@ test_that("fitdistdoublecens works correctly", {
   expect_false(is.na(fit$bic))
 })
 
+test_that("fitdistdoublecens works with deprecated numeric inputs", {
+  # Set seed for reproducibility
+  set.seed(123)
+
+  # Define true distribution parameters
+  n <- 1000
+  shape <- 1.77
+  rate <- 0.44
+
+  # Generate samples
+  samples <- rprimarycensored(
+    n,
+    rgamma,
+    shape = shape,
+    rate = rate,
+    pwindow = 1,
+    swindow = 1,
+    D = 8
+  )
+
+  # Create data frame without pwindow and D columns
+  delay_data <- data.frame(
+    left = samples,
+    right = samples + 1
+  )
+
+  # Test with deprecated numeric inputs for pwindow and D
+  expect_warning(
+    fit <- fitdistdoublecens(
+      delay_data,
+      distr = "gamma",
+      start = list(shape = 1, rate = 1),
+      pwindow = 1,
+      D = 8
+    ),
+    "deprecated"
+  )
+
+  # Check that the function returns a fitdist object
+  expect_s3_class(fit, "fitdist")
+
+  # Check that the estimated parameters are close to the true values
+  expect_equal(unname(fit$estimate["shape"]), shape, tolerance = 0.2)
+  expect_equal(unname(fit$estimate["rate"]), rate, tolerance = 0.2)
+})
+
 test_that("fitdistdoublecens handles errors correctly", {
-  # Test with invalid input
+  # Test with missing columns
   expect_error(
     fitdistdoublecens(
-      data.frame(x = 1:10), # Missing 'left' and 'right' columns
+      data.frame(x = 1:10), # Missing required columns
       distr = "gamma"
     ),
-    "censdata must contain 'left' and 'right' columns"
+    "Missing required columns"
   )
 
   # Test with non-existent distribution
   expect_error(
     fitdistdoublecens(
-      data.frame(left = 1:10, right = 2:11),
+      data.frame(
+        left = 1:10,
+        right = 2:11,
+        pwindow = rep(1, 10),
+        D = rep(10, 10)
+      ),
       distr = "nonexistent_dist"
     )
   )
@@ -76,21 +132,26 @@ test_that("fitdistdoublecens works with different distributions", {
   true_mean <- 5
   true_sd <- 2
   samples <- rprimarycensored(
-    n, rnorm,
-    mean = true_mean, sd = true_sd,
-    pwindow = 2, swindow = 2, D = 10
+    n,
+    rnorm,
+    mean = true_mean,
+    sd = true_sd,
+    pwindow = 2,
+    swindow = 2,
+    D = 10
   )
 
   delay_data <- data.frame(
-    left = samples
+    left = samples,
+    right = samples + 2,
+    pwindow = rep(2, n),
+    D = rep(10, n)
   )
-  delay_data$right <- delay_data$left + 2
 
   fit_norm <- fitdistdoublecens(
     delay_data,
     distr = "norm",
-    start = list(mean = 0, sd = 1),
-    D = 10, pwindow = 2
+    start = list(mean = 0, sd = 1)
   )
 
   expect_s3_class(fit_norm, "fitdist")
@@ -107,12 +168,15 @@ test_that("fitdistdoublecens works with mixed secondary windows", {
   true_rate <- 0.5
 
   # Generate samples with mixed secondary windows
-  # Generate samples with mixed secondary windows
   generate_sample <- function(pwindow, swindow, obs_time) {
     rpcens(
-      1, rgamma,
-      shape = true_shape, rate = true_rate,
-      pwindow = pwindow, swindow = swindow, D = obs_time
+      1,
+      rgamma,
+      shape = true_shape,
+      rate = true_rate,
+      pwindow = pwindow,
+      swindow = swindow,
+      D = obs_time
     )
   }
 
@@ -123,15 +187,16 @@ test_that("fitdistdoublecens works with mixed secondary windows", {
   samples <- mapply(generate_sample, pwindows, swindows, obs_times)
 
   delay_data <- data.frame(
-    left = samples
+    left = samples,
+    right = samples + swindows,
+    pwindow = pwindows,
+    D = obs_times
   )
-  delay_data$right <- delay_data$left + swindows
 
   fit_gamma <- fitdistdoublecens(
     delay_data,
     distr = "gamma",
-    start = list(shape = 2, rate = 1),
-    D = 10, pwindow = 1
+    start = list(shape = 2, rate = 1)
   )
 
   expect_s3_class(fit_gamma, "fitdist")
@@ -139,59 +204,191 @@ test_that("fitdistdoublecens works with mixed secondary windows", {
   expect_equal(unname(fit_gamma$estimate["rate"]), true_rate, tolerance = 0.2)
 })
 
-test_that(
-  "fitdistdoublecens throws error when required packages are not installed",
-  {
-    # Create dummy data
-    dummy_data <- data.frame(left = 1:5, right = 2:6)
+test_that("fitdistdoublecens works with mixed D and primary windows", {
+  set.seed(789)
+  n <- 1000
 
-    # Test for fitdistrplus
-    with_mocked_bindings(
-      {
-        expect_error(
-          fitdistdoublecens(dummy_data, "norm"),
-          "Package 'fitdistrplus' is required but not installed for this",
-          fixed = TRUE
-        )
-      },
-      requireNamespace = function(pkg, ...) {
-        if (pkg == "fitdistrplus") {
-          return(FALSE)
-        }
-        TRUE
-      },
-      .package = "base"
-    )
+  # True parameters for gamma distribution
+  true_shape <- 2.5
+  true_rate <- 0.6
 
-    # Test for withr
-    with_mocked_bindings(
-      {
-        expect_error(
-          fitdistdoublecens(dummy_data, "norm"),
-          "Package 'withr' is required but not installed for this function.",
-          fixed = TRUE
-        )
-      },
-      requireNamespace = function(pkg, ...) {
-        if (pkg == "withr") {
-          return(FALSE)
-        }
-        TRUE
-      },
-      .package = "base"
-    )
-
-    # Test when both packages are missing
-    with_mocked_bindings(
-      {
-        expect_error(
-          fitdistdoublecens(dummy_data, "norm"),
-          "Package 'fitdistrplus' is required but not installed",
-          fixed = TRUE
-        )
-      },
-      requireNamespace = function(...) FALSE,
-      .package = "base"
+  # Generate samples with mixed D and primary windows
+  generate_sample <- function(pwindow, swindow, obs_time) {
+    rpcens(
+      1,
+      rgamma,
+      shape = true_shape,
+      rate = true_rate,
+      pwindow = pwindow,
+      swindow = swindow,
+      D = obs_time
     )
   }
-)
+
+  # Create mixed pwindows and D values
+  pwindows <- sample(c(1, 2), n, replace = TRUE)
+  swindows <- rep(1, n)
+  obs_times <- sample(c(8, 12), n, replace = TRUE)
+
+  samples <- mapply(generate_sample, pwindows, swindows, obs_times)
+
+  delay_data <- data.frame(
+    left = samples,
+    right = samples + swindows,
+    pwindow = pwindows,
+    D = obs_times
+  )
+
+  fit_gamma <- fitdistdoublecens(
+    delay_data,
+    distr = "gamma",
+    start = list(shape = 2, rate = 1)
+  )
+
+  expect_s3_class(fit_gamma, "fitdist")
+  expect_equal(unname(fit_gamma$estimate["shape"]), true_shape, tolerance = 0.3)
+  expect_equal(unname(fit_gamma$estimate["rate"]), true_rate, tolerance = 0.3)
+})
+
+test_that("fitdistdoublecens works with custom column names", {
+  set.seed(123)
+  n <- 1000
+  shape <- 1.77
+  rate <- 0.44
+
+  samples <- rprimarycensored(
+    n,
+    rgamma,
+    shape = shape,
+    rate = rate,
+    pwindow = 1,
+    swindow = 1,
+    D = 8
+  )
+
+  # Create data frame with custom column names
+  delay_data <- data.frame(
+    lower_bound = samples,
+    upper_bound = samples + 1,
+    primary_window = rep(1, n),
+    truncation_time = rep(8, n)
+  )
+
+  fit <- fitdistdoublecens(
+    delay_data,
+    distr = "gamma",
+    start = list(shape = 1, rate = 1),
+    left = "lower_bound",
+    right = "upper_bound",
+    pwindow = "primary_window",
+    D = "truncation_time"
+  )
+
+  expect_s3_class(fit, "fitdist")
+  expect_equal(unname(fit$estimate["shape"]), shape, tolerance = 0.2)
+  expect_equal(unname(fit$estimate["rate"]), rate, tolerance = 0.2)
+})
+
+test_that("fitdistdoublecens handles truncation_check_multiplier correctly", {
+  set.seed(123)
+  n <- 100
+  shape <- 1.77
+  rate <- 0.44
+
+  samples <- rprimarycensored(
+    n,
+    rgamma,
+    shape = shape,
+    rate = rate,
+    pwindow = 1,
+    swindow = 1,
+    D = 100 # Very large D
+  )
+
+  delay_data <- data.frame(
+    left = samples,
+    right = samples + 1,
+    pwindow = rep(1, n),
+    D = rep(100, n)
+  )
+
+  # Should show a message about large D
+  expect_message(
+    fitdistdoublecens(
+      delay_data,
+      distr = "gamma",
+      start = list(shape = 1, rate = 1),
+      truncation_check_multiplier = 2
+    ),
+    "truncation time D"
+  )
+
+  # Should not show a message when check is disabled
+  expect_no_message(
+    fitdistdoublecens(
+      delay_data,
+      distr = "gamma",
+      start = list(shape = 1, rate = 1),
+      truncation_check_multiplier = NULL
+    )
+  )
+})
+
+test_that("fitdistdoublecens throws error when required packages are not installed", {
+  # Create dummy data
+  dummy_data <- data.frame(
+    left = 1:5,
+    right = 2:6,
+    pwindow = rep(1, 5),
+    D = rep(10, 5)
+  )
+
+  # Test for fitdistrplus
+  with_mocked_bindings(
+    {
+      expect_error(
+        fitdistdoublecens(dummy_data, "norm"),
+        "Package 'fitdistrplus' is required but not installed for this",
+        fixed = TRUE
+      )
+    },
+    requireNamespace = function(pkg, ...) {
+      if (pkg == "fitdistrplus") {
+        return(FALSE)
+      }
+      TRUE
+    },
+    .package = "base"
+  )
+
+  # Test for withr
+  with_mocked_bindings(
+    {
+      expect_error(
+        fitdistdoublecens(dummy_data, "norm"),
+        "Package 'withr' is required but not installed for this function.",
+        fixed = TRUE
+      )
+    },
+    requireNamespace = function(pkg, ...) {
+      if (pkg == "withr") {
+        return(FALSE)
+      }
+      TRUE
+    },
+    .package = "base"
+  )
+
+  # Test when both packages are missing
+  with_mocked_bindings(
+    {
+      expect_error(
+        fitdistdoublecens(dummy_data, "norm"),
+        "Package 'fitdistrplus' is required but not installed",
+        fixed = TRUE
+      )
+    },
+    requireNamespace = function(...) FALSE,
+    .package = "base"
+  )
+})

--- a/tests/testthat/test-fitdistdoublecens.R
+++ b/tests/testthat/test-fitdistdoublecens.R
@@ -1,3 +1,4 @@
+# fmt: skip file
 # Skip tests if fitdistrplus is not installed
 if (!requireNamespace("fitdistrplus", quietly = TRUE)) {
   skip("Package 'fitdistrplus' is required for these tests")
@@ -81,16 +82,16 @@ test_that("fitdistdoublecens works with deprecated numeric inputs", {
   )
 
   # Test with deprecated numeric inputs for pwindow and D
-  suppressWarnings(
-    expect_warning(
-      fit <- fitdistdoublecens( # nolint
-        delay_data,
-        distr = "gamma",
-        start = list(shape = 1, rate = 1),
-        pwindow = 1,
-        D = 8
+  suppressWarnings(expect_warning(
+    fit <- fitdistdoublecens(
+      # nolint
+      delay_data,
+      distr = "gamma",
+      start = list(shape = 1, rate = 1),
+      pwindow = 1,
+      D = 8
     )
-  )
+  ))
 
   # Check that the function returns a fitdist object
   expect_s3_class(fit, "fitdist")

--- a/tests/testthat/test-fitdistdoublecens.R
+++ b/tests/testthat/test-fitdistdoublecens.R
@@ -83,7 +83,7 @@ test_that("fitdistdoublecens works with deprecated numeric inputs", {
 
   # Test with deprecated numeric inputs for pwindow and D
   suppressWarnings(expect_warning(
-    fit <- fitdistdoublecens(
+    fit <- fitdistdoublecens( # nolint
       # nolint
       delay_data,
       distr = "gamma",
@@ -335,7 +335,8 @@ test_that("fitdistdoublecens handles truncation_check_multiplier correctly", {
   )
 })
 
-test_that("fitdistdoublecens throws error when required packages are not installed", {
+test_that(
+  "fitdistdoublecens throws error when required packages are not installed", {
   # Create dummy data
   dummy_data <- data.frame(
     left = 1:5,
@@ -346,13 +347,11 @@ test_that("fitdistdoublecens throws error when required packages are not install
 
   # Test for fitdistrplus
   with_mocked_bindings(
-    {
-      expect_error(
-        fitdistdoublecens(dummy_data, "norm"),
-        "Package 'fitdistrplus' is required but not installed for this",
-        fixed = TRUE
-      )
-    },
+    expect_error(
+      fitdistdoublecens(dummy_data, "norm"),
+      "Package 'fitdistrplus' is required but not installed for this",
+      fixed = TRUE
+    ),
     requireNamespace = function(pkg, ...) {
       if (pkg == "fitdistrplus") {
         return(FALSE)
@@ -364,13 +363,11 @@ test_that("fitdistdoublecens throws error when required packages are not install
 
   # Test for withr
   with_mocked_bindings(
-    {
-      expect_error(
-        fitdistdoublecens(dummy_data, "norm"),
-        "Package 'withr' is required but not installed for this function.",
-        fixed = TRUE
-      )
-    },
+    expect_error(
+      fitdistdoublecens(dummy_data, "norm"),
+      "Package 'withr' is required but not installed for this function.",
+      fixed = TRUE
+    ),
     requireNamespace = function(pkg, ...) {
       if (pkg == "withr") {
         return(FALSE)
@@ -382,13 +379,11 @@ test_that("fitdistdoublecens throws error when required packages are not install
 
   # Test when both packages are missing
   with_mocked_bindings(
-    {
-      expect_error(
-        fitdistdoublecens(dummy_data, "norm"),
-        "Package 'fitdistrplus' is required but not installed",
-        fixed = TRUE
-      )
-    },
+    expect_error(
+      fitdistdoublecens(dummy_data, "norm"),
+      "Package 'fitdistrplus' is required but not installed",
+      fixed = TRUE
+    ),
     requireNamespace = function(...) FALSE,
     .package = "base"
   )

--- a/vignettes/fitting-dists-with-fitdistrplus.Rmd
+++ b/vignettes/fitting-dists-with-fitdistrplus.Rmd
@@ -81,11 +81,10 @@ samples <- mapply(generate_sample, pwindows, swindows, obs_times)
 
 # Create initial data frame
 delay_data <- data.frame(
+  delay = samples,
+  delay_upper = samples + swindows,
   pwindow = pwindows,
-  swindow = swindows,
-  obs_time = obs_times,
-  observed_delay = samples,
-  observed_delay_upper = samples + swindows
+  relative_obs_time = obs_times
 )
 
 head(delay_data)
@@ -146,7 +145,7 @@ We first fit a naive model using the `fitdistcens()` function. This function is 
 
 ```{r fit-naive-model}
 fit <- delay_data |>
-  dplyr::select(left = observed_delay, right = observed_delay_upper) |>
+  dplyr::select(left = delay, right = delay_upper) |>
   fitdistcens(
     distr = "gamma",
     start = list(shape = 1, rate = 1)
@@ -202,8 +201,8 @@ ppcens_gamma <- function(q, shape, rate) {
 
 # Fit the model using fitdistcens with custom gamma distribution
 pcens_fit <- delay_data |>
-  dplyr::filter(obs_time == 8) |>
-  dplyr::pull(observed_delay) |>
+  dplyr::filter(relative_obs_time == 8) |>
+  dplyr::pull(delay) |>
   fitdist(
     distr = "pcens_gamma",
     start = list(shape = 1, rate = 1)
@@ -215,23 +214,23 @@ summary(pcens_fit)
 We see good agreement between the true and estimated parameters but with higher standard errors due to using a subset of the data.
 
 Rather than using `fitdist()` directly `primarycensored` provides a wrapper function `fitdistdoublecens()` that can be used to estimate double censored and truncated data.
-A bonus of this approach is we can specify our data using the `fitdistcens` `left` and `right` formulation and support mixed secondary censoring intervals.
+A bonus of this approach is we can specify our data using the `fitdistcens` `left` and `right` formulation and support mixed censoring intervals.
 Another bonus of this approach is that it supports a mixture of observation times so we can fit to all the available data rather than the subset we used in the custom implementation above.
 
 ```{r primarycensored-fitdistdoublecens}
-fitdistdoublecens_fit <- delay_data |>
-  dplyr::select(left = observed_delay, right = observed_delay_upper) |>
-  fitdistdoublecens(
-    distr = "gamma",
-    start = list(shape = 1, rate = 1),
-    pwindow = 1
-  )
+# Using Stan-like interface but with fitdistrplus
+fitdistdoublecens_fit <- fitdistdoublecens(
+  delay_data,
+  distr = "gamma",
+  start = list(shape = 1, rate = 1),
+  left = "delay",
+  right = "delay_upper",
+  pwindow = "pwindow",
+  D = "relative_obs_time"
+)
 
 summary(fitdistdoublecens_fit)
 ```
-
-
-**Note** Currently this functionality is limited to a single pwindow. If this functionality is of interest then please open an issue on the `primarycensored` GitHub page.
 
 ## Summary
 

--- a/vignettes/fitting-dists-with-fitdistrplus.Rmd
+++ b/vignettes/fitting-dists-with-fitdistrplus.Rmd
@@ -65,7 +65,7 @@ rate <- 0.44
 # Generate fixed pwindow, swindow, and obs_time
 pwindows <- rep(1, n)
 swindows <- rep(1, n)
-obs_times <- rep(8, n) # Truncation at 8
+obs_times <- sample(8:10, n, replace = TRUE)
 
 # Function to generate a single sample
 generate_sample <- function(pwindow, swindow, obs_time) {
@@ -96,7 +96,7 @@ head(delay_data)
 empirical_cdf <- ecdf(samples)
 
 # Create a sequence of x values for the theoretical CDF
-x_seq <- seq(0, 8, length.out = 100)
+x_seq <- seq(0, 10, length.out = 100)
 
 # Calculate theoretical CDF
 theoretical_cdf <- pgamma(x_seq, shape = shape, rate = rate)
@@ -135,7 +135,7 @@ ggplot(cdf_data, aes(x = x, y = probability, color = type)) +
     plot.title = element_text(hjust = 0.5),
     legend.position = "bottom"
   ) +
-  coord_cartesian(xlim = c(0, 8)) # Set x-axis limit to match truncation
+  coord_cartesian(xlim = c(0, 10)) # Set x-axis limit to match truncation
 ```
 
 In this figure you can see the impact of truncation and censoring as the observed distribution has a much lower mean (the vertical dashed blue line) than the true/theoretical distribution (the vertical dashed black line). Our modelling aim is to recover the true parameters of the theoretical distribution from the observed distribution (i.e. recover the black lines from the blue lines).
@@ -159,7 +159,11 @@ We see that the naive model has fit poorly due to the primary censoring and righ
 
 # Fitting an improved model using `primarycensored` and `fitdistrplus`
 
-We'll now fit an improved model using the `primarycensored` package. To do this we need to define the custom distribution functions using the `primarycensored` package that are required by `fitdistrplus`. Rather than using `fitdistcens` we use `fitdist` because our functions are handling the censoring themselves.
+We'll now fit an improved model using the `primarycensored` package.
+To do this we need to define the custom distribution functions using the `primarycensored` package that are required by `fitdistrplus`.
+Rather than using `fitdistcens` we use `fitdist` because our functions are handling the censoring themselves.
+Note that in this custom implementation for simplicity we are filtering to use only data with the same `obs_time` rather than handling varying observation times.
+This means we're using a subset of our simulated data for the estimation.
 
 ```{r fit-improved-model}
 # Define custom distribution functions using primarycensored
@@ -186,7 +190,7 @@ ppcens_gamma <- function(q, shape, rate) {
       pprimarycensored(
         q, pgamma,
         shape = shape, rate = rate,
-        pwindow = 1, D = 8
+        dpwindow = 1, D = 8
       )
     },
     error = function(e) {
@@ -197,7 +201,9 @@ ppcens_gamma <- function(q, shape, rate) {
 }
 
 # Fit the model using fitdistcens with custom gamma distribution
-pcens_fit <- samples |>
+pcens_fit <- delay_data |>
+  dplyr::filter(obs_time == 8) |>
+  dplyr::pull(observed_delay) |>
   fitdist(
     distr = "pcens_gamma",
     start = list(shape = 1, rate = 1)
@@ -206,9 +212,11 @@ pcens_fit <- samples |>
 summary(pcens_fit)
 ```
 
-We see very good agreement between the true and estimated parameters.
+We see good agreement between the true and estimated parameters but with higher standard errors due to using a subset of the data.
 
-Rather than using `fitdist()` directly `primarycensored` provides a wrapper function `fitdistdoublecens()` that can be used to estimate double censored and truncated data. A bonus of this approach is we can specify our data using the `fitdistcens` `left` and `right` formulation and support mixed secondary censoring intervals.
+Rather than using `fitdist()` directly `primarycensored` provides a wrapper function `fitdistdoublecens()` that can be used to estimate double censored and truncated data.
+A bonus of this approach is we can specify our data using the `fitdistcens` `left` and `right` formulation and support mixed secondary censoring intervals.
+Another bonus of this approach is that it supports a mixture of observation times so we can fit to all the available data rather than the subset we used in the custom implementation above.
 
 ```{r primarycensored-fitdistdoublecens}
 fitdistdoublecens_fit <- delay_data |>
@@ -216,14 +224,14 @@ fitdistdoublecens_fit <- delay_data |>
   fitdistdoublecens(
     distr = "gamma",
     start = list(shape = 1, rate = 1),
-    D = 8, pwindow = 1
+    pwindow = 1
   )
 
 summary(fitdistdoublecens_fit)
 ```
 
 
-**Note** Currently this functionality is limited to a single pwindow, and observation time for all data. If this functionality is of interest then please open an issue on the `primarycensored` GitHub page.
+**Note** Currently this functionality is limited to a single pwindow. If this functionality is of interest then please open an issue on the `primarycensored` GitHub page.
 
 ## Summary
 


### PR DESCRIPTION
<!-- Thanks for opening this pull request! Below we have provided a suggested template for PRs to this repository and a checklist to complete before opening a PR -->
 
## Description

This PR closes #71 by adding support as in the title for more complex data (in line with the stan functionality). I have tried to keep the interface close to the R code and the `fitdistrplus` package but this does mean there is some disconnect with Stan interface. Personally I think this is fine as most uses are likely to use one or the other  but in a future issue we could address this (for example making the stan interface use D rather than the relative_obs_time or vice versa).

The outstanding issue with this PR is that the current `main` approach of using `with_environment` fails here. It works the first time the function is run on a fresh load and then fails with a corrupt binding error coming from the internal attach call. This is a bit tricky to understand but it has to be from one of the changes made here. So far I have: 

- Checked main again
- Removed the passing of a dataframe and insteaded passed each input as a vector.

I think the very dull debug path is to unpick the changes back towards main and see what caused the issue. I think the way to do this is to first unpick the internal changes and then if that works revert the user facing changes but keep the internals.

## Updates

I have avoided the environment issue by creating a new environment and controlling what objects are in it. This seems to do the trick

## Checklist

- [x] My PR is based on a package issue and I have explicitly linked it.
- [x] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [x] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [x] I have tested my changes locally.
- [x] I have added or updated unit tests where necessary.
- [x] I have updated the documentation if required.
- [x] My code follows the established coding standards.
- [ ] I have added a news item linked to this PR.
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->
