### PR TITLE
Add callout box highlighting why primarycensored is useful

### DIFF
--- a/vignettes/why-it-works.Rmd
+++ b/vignettes/why-it-works.Rmd
@@ -38,9 +38,11 @@ Time-to-event analysis, also known as survival analysis, concerns estimating the
 
 In statistical epidemiology, these missing data problems occur frequently in both data analysis and theoretical modelling. For a more detailed description of these problems in an epidemiological context see [@Park2024; @Charniga2024].
 
-In data analysis, events in epidemiology are commonly reported as occurring on a particular day or week (*interval censoring*). In an emerging outbreak, datasets can be incompletely observed (*right truncation*) and their can be a great deal of uncertainty around the precise timing of events (*interval censoring*).
+::: {.alert .alert-info}
+**For data analysis**: In epidemiology, events are commonly reported as occurring on a particular day or week. This means that *both* events that define a delay are interval censored. In an emerging outbreak, datasets can also be incompletely observed (*right truncation*). `primarycensored` provides statistically rigorous methods to account for this double censoring and truncation.
 
-In theoretical epidemiological modelling, it is often appropriate to model the evolution of an infectious disease as occurring in discrete time, for example in the [`EpiNow2`](https://epiforecasts.io/EpiNow2/) and [`EpiEstim`](https://mrc-ide.github.io/EpiEstim/index.html) modelling packages. This means appropriately discretising continuous distributions, such as the generation interval distribution. In `primarycensored` we treat the discretisation of intrinsically continuous distributions as an *interval censoring* problem which allows us to simultaneously provide methods for both applied and theoretical contexts.
+**For theoretical modelling**: Discrete-time models (e.g., [`EpiNow2`](https://epiforecasts.io/EpiNow2/), [`EpiEstim`](https://mrc-ide.github.io/EpiEstim/index.html)) implicitly treat both events as interval censored at the model's timestep. `primarycensored` provides a principled approach to discretising continuous distributions that accounts for this.
+:::
 
 # Statistical model used in `primarycensored`
 


### PR DESCRIPTION
Title:

Add callout box highlighting why primarycensored is useful

Body:

## Summary
- Adds a styled callout box in the "Why it works" vignette that emphasizes the two main use cases for `primarycensored`
- Highlights **data analysis** use case: handling interval censoring and right truncation when estimating delay distributions
- Highlights **theoretical modelling** use case: discretising continuous distributions for models like EpiNow2 and EpiEstim

Closes #199

## Test plan
- [ ] Verify the vignette renders correctly with `pkgdown::build_article("why-it-works")`
- [ ] Check that the alert box displays properly in the rendered HTML

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured package introduction with enhanced explanations for data analysis and theoretical modeling use cases.
  * Improved presentation with visual info alerts and updated formatting for better readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->