### PR TITLE
Issue 286: fix doi

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -30,7 +30,10 @@ license](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/
 ## Summary
 
 ```{r, results = "asis", echo=FALSE}
-cat(gsub("\n[ ]+", " ", packageDescription("primarycensored")$Description))
+desc_file <- read.dcf("DESCRIPTION")
+description <- gsub("\n[ ]+", " ", desc_file[1, "Description"])
+description <- gsub("<doi:([^>]+)>", "[doi:\\1](https://doi.org/\\1)", description)
+cat(description)
 ```
 
 ## Installation


### PR DESCRIPTION
## Description

This PR closes #286.

It edits the Rmd to pull the Description and adds an https://doi.org/ so that the doi is clickable. 

Here's the rendered markdown.
<img width="964" height="262" alt="Screenshot 2026-03-17 at 16 10 47" src="https://github.com/user-attachments/assets/504986ea-d022-4d0e-ae65-103c76225b27" />

## Checklist

- [X] My PR is based on a package issue and I have explicitly linked it.
- [X] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [X] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [X] I have tested my changes locally.
- [X] I have added or updated unit tests where necessary.
- [X] I have updated the documentation if required.
- [X] My code follows the established coding standards.
- [ ] I have added a news item linked to this PR.
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced README rendering with improved description formatting
  * Optimized DOI references to display as properly formatted Markdown links for better documentation clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->