### PR TITLE
fix: url typo [skip ci]

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -109,7 +109,7 @@ Please note that the `primarycensored` project is released with a [Contributor C
 
 ## Citation
 
-If making use of our methodology or the methodology on which ours is based, please cite the relevant papers from our [methods outline](https://primarycensored.epinowcast.org/articles//primarycensored.html). If you use `primarycensored` in your work, please consider citing it with `citation("primarycensored")`.
+If making use of our methodology or the methodology on which ours is based, please cite the relevant papers from our [methods outline](https://primarycensored.epinowcast.org/articles/primarycensored.html). If you use `primarycensored` in your work, please consider citing it with `citation("primarycensored")`.
 
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ By contributing to this project, you agree to abide by its terms.
 
 If making use of our methodology or the methodology on which ours is
 based, please cite the relevant papers from our [methods
-outline](https://primarycensored.epinowcast.org/articles//primarycensored.html).
+outline](https://primarycensored.epinowcast.org/articles/primarycensored.html).
 If you use `primarycensored` in your work, please consider citing it
 with `citation("primarycensored")`.
 


### PR DESCRIPTION
This had issues with the rendered version it links to (I assume due to broken js/css links)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected malformed links in README documentation by removing duplicate and extra slashes in URLs, ensuring proper navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->